### PR TITLE
its a fucking ship, not a station (shuttleloan.dm change)

### DIFF
--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -29,7 +29,7 @@
 	SSshuttle.shuttle_loan = src
 	switch(dispatch_type)
 		if(HIJACK_SYNDIE)
-			priority_announce("Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache.","CentCom Counter Intelligence")
+			priority_announce("Cargo: The syndicate are trying to infiltrate your ship. If you let them hijack your cargo shuttle, you'll save us a headache.","CentCom Counter Intelligence")
 		if(RUSKY_PARTY)
 			priority_announce("Cargo: A group of angry Russians want to have a party. Can you send them your cargo shuttle then make them disappear?","CentCom Russian Outreach Program")
 		if(SPIDER_GIFT)


### PR DESCRIPTION


## About The Pull Request

changes ''station'' to ''ship'' in shutteloan.dm

## Why It's Good For The Game

accuracy good

## Changelog
:cl:
tweak: makes it say ''ship'' when the shuttle gets loaned
/:cl:

